### PR TITLE
Make debug output better and stop sending spaces to the fifo.

### DIFF
--- a/pterosaur.js
+++ b/pterosaur.js
@@ -492,13 +492,15 @@ function startVimbed(debug) {
 
   vimProcess.init(FileUtils.File('/bin/sh'));
   //Note: +clientserver doesn't work for some values of TERM (like linux)
-  let TERM = services.environment.get("TERM");
-  if (!TERM)
-      TERM = "xterm";
   if (debug)
+  {
+    let TERM = services.environment.get("TERM");
+    if (!TERM || TERM === "linux")
+        TERM = "xterm";
     vimProcess.runAsync([ '-c',"TERM="+TERM+" vim --servername pterosaur_"+uid+" +'call Vimbed_SetupVimbed(\"\",\"\")' </tmp/vimbed/pterosaur_"+uid+"/fifo"],2);
+  }
   else
-    vimProcess.runAsync([ '-c',"TERM="+TERM+" vim --servername pterosaur_"+uid+" +'call Vimbed_SetupVimbed(\"\",\"\")' </tmp/vimbed/pterosaur_"+uid+"/fifo >/dev/null"],2);
+    vimProcess.runAsync([ '-c',"TERM=xterm vim --servername pterosaur_"+uid+" +'call Vimbed_SetupVimbed(\"\",\"\")' </tmp/vimbed/pterosaur_"+uid+"/fifo >/dev/null"],2);
 
   //We have to send SOMETHING to the fifo or vim will stay open when we close.
   io.system("echo -n '\e' > /tmp/vimbed/pterosaur_"+uid+"/fifo")


### PR DESCRIPTION
When using 'pterosaurdebug' the output can be ugly/garbled if you aren't using xterm. The first commit will change the behavior to use the $TERM environment variable.
In 'startVimbed', you send a space to the fifo. In Vim, this may be mapped to do just about anything. The only thing guaranteed to be safe (I hope anyways) to send is an escape character. The second commit fixes this.
